### PR TITLE
add README, docs from video.js repo, and governance doc

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run build

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,104 @@
+# Video.js® Contributor Code of Conduct
+
+Please note that projects within the Video.js organization are released with a Contributor Code of Conduct. By participating in any of these projects you agree to abide by its terms.
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Our Pledge](#our-pledge)
+- [Our Standards](#our-standards)
+- [Our Responsibilities](#our-responsibilities)
+- [Scope](#scope)
+  - [Other Community Standards](#other-community-standards)
+- [Enforcement](#enforcement)
+  - [Further Enforcement](#further-enforcement)
+  - [Who Watches the Watchers?](#who-watches-the-watchers)
+- [Attribution](#attribution)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+The [Technical Steering Committee (TSC)][tsc] are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+The TSC have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by the TSC.
+
+### Other Community Standards
+
+As a project on GitHub, this project is additionally covered by the [GitHub Community Guidelines](https://help.github.com/articles/github-community-guidelines/).
+
+Additionally, as a project hosted on npm, is is covered by [npm, Inc's Code of Conduct](https://www.npmjs.com/policies/conduct).
+
+Enforcement of those guidelines after violations overlapping with the above are the responsibility of the entities, and enforcement may happen in any or all of the services/communities.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a [member of the Technical Steering Committee][tsc].
+
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+Further details of specific enforcement policies may be posted separately.
+
+TSC members who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+### Further Enforcement
+
+If you've already followed the [initial enforcement steps](#enforcement), these are the steps the TSC will take for further enforcement, as needed:
+
+1. Repeat the request to stop.
+1. If the person doubles down, they will have offending messages removed or edited by a TSC member given an official warning. The PR or Issue may be locked.
+1. If the behavior continues or is repeated later, the person will be blocked from participating for 24 hours.
+1. If the behavior continues or is repeated after the temporary block, a long-term (6-12mo) ban will be used.
+
+On top of this, the TSC may remove any offending messages, images, contributions, etc, as they deem necessary.
+
+Maintainers reserve full rights to skip any of these steps, at their discretion, if the violation is considered to be a serious and/or immediate threat to the health and well-being of members of the community. These include any threats, serious physical or verbal attacks, and other such behavior that would be completely unacceptable in any social setting that puts our members at risk.
+
+Members expelled from events or venues with any sort of paid attendance will not be refunded.
+
+### Who Watches the Watchers?
+
+TSC members who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the TSC. These may include anything from removal from the TSC member to a permanent ban from the community.
+
+Additionally, as a project hosted on both GitHub and npm, [their own Codes of Conducts may be applied against maintainers of this project](#other-community-standards), externally of this project's procedures.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+The [Other Community Standards](#other-community-standards), [Further Enforcement](#further-enforcement), and [Who Watches the Watchers?](#who-watches-the-watchers) sections are based on [weallbehave][weallbehave],
+which is based on the [WeAllJS Code of Conduct][wealljs].
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/
+[wealljs]: https://wealljs.org/code-of-conduct
+[weallbehave]: https://npm.im/weallbehave
+[tsc]: ./GOVERNANCE.md#current-tsc-members

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -1,0 +1,466 @@
+# Video.js® Collaborator Guide
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Issues and Pull Requests](#issues-and-pull-requests)
+  - [Labels](#labels)
+- [Accepting changes](#accepting-changes)
+  - [Involving the TSC](#involving-the-tsc)
+- [Landing a PR](#landing-a-pr)
+  - [Landing a PR manually](#landing-a-pr-manually)
+    - [Landing a PR manually with several changes](#landing-a-pr-manually-with-several-changes)
+    - [I just made a mistake](#i-just-made-a-mistake)
+      - [I accidentally pushed a broken commit or incorrect commit to main](#i-accidentally-pushed-a-broken-commit-or-incorrect-commit-to-main)
+      - [I lost changes](#i-lost-changes)
+      - [I accidentally committed a broken change to main](#i-accidentally-committed-a-broken-change-to-main)
+- [Video.js releases](#videojs-releases)
+  - [Getting dependencies](#getting-dependencies)
+    - [npm access](#npm-access)
+  - [Deciding what type of version release](#deciding-what-type-of-version-release)
+  - [Doing a release](#doing-a-release)
+    - [Current Video.js](#current-videojs)
+    - [Legacy Video.js (5)](#legacy-videojs-5)
+      - [Edit git-semver-tags](#edit-git-semver-tags)
+    - [And now for the release](#and-now-for-the-release)
+  - [Deploy as a patch to the CDN](#deploy-as-a-patch-to-the-cdn)
+  - [Announcement](#announcement)
+- [Doc credit](#doc-credit)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Issues and Pull Requests
+
+Full courtesy should always be shown in Video.js projects.
+
+Collaborators may manage issues they feel qualified to handle, being mindful of our guidelines.
+
+Any issue and PR can be closed if they are not relevant, when in doubt leave it open for more discussion. Issues can always be re-opened if new information is made available.
+
+If issues or PRs are very short and don't contain much information, ask for more by linking to the [issue][issue template] or [PR][pr template] template. There is also a [response guide](https://github.com/videojs/video.js/wiki/New-Issue-Response-Guide) if you're unsure.
+
+### Labels
+
+There are labels that are useful to include on issues and PRs. A few of them are defined below:
+
+| Label                    | Issue or PR  | Description                                                                |
+| ------------------------ | ------------ | -------------------------------------------------------------------------- |
+| confirmed                | Issue and PR | Issue: marks as reproducible. PR: marks as ready to be merged              |
+| 5.x                      | PR           | Marks as a change to the 5.x branch only                                   |
+| bug                      | Issue        | Marks as a confirmed bug                                                   |
+| good first issue         | Issue        | Marks as a good bug or enhancement for first time contributors to Video.js |
+| first-timers-only        | Issue        | Marks as a good bug or enhancement to be done by a newcomer to open source |
+| minor, patch, major      | PR           | Marks PR with the expected semver classification of the change             |
+| needs: LGTM              | PR           | Marks PR to be reviewed by a collaborator                                  |
+| needs: more info         | Issue        | Marks as needing more information from the issue reporter                  |
+| needs: reduced test case | Issue        | Marks as needing a reduced test case from the issue reporter               |
+
+## Accepting changes
+
+Any code change in Video.js should be happening through Pull Requests on GitHub. This includes core committers.
+
+Before a PR is merged, it must be reviewed by at least two core committers, at least one if it comes from a core committer.
+
+Feel free to @-mention a particular core committer if you know they are experts in the area that is being changed.
+
+If you are unsure about the modification and cannot take responsibility for it, defer to another core committer.
+
+Before merging the change, it should be left open for other core committers to comment on. At least 24 hours during a weekday, and the 48 hours on a weekend. Trivial changes or bug fixes that have been reviewed by multiple committers may be merged without delay.
+
+For non-breaking changes, if there is no disagreement between the collaborators, the PR may be landed assuming it was reviewed. If there is still disagreement, it may need to be [escalated to the TSC](#involving-the-tsc).
+
+Bug fixes require a test case that fails beforehand and succeeds after. All code changes should contain tests and pass on the CI.
+
+### Involving the TSC
+
+A change or issue can be elevated to the TSC by assing the `tsc-agent` label. This should be done in the following scenarios:
+
+* There will be a major impact on the codebase or project
+* The change is inherently controversial
+* No agreement was reached between collaborators participating in the discussion
+
+The TSC will be the final arbiter when required.
+
+## Landing a PR
+
+Landing a PR is fairly easy given that we can use the GitHub UI for it.
+
+When using the big green button on GitHub, make sure the "squash and merge" is selected -- it should be the only allowed option. If a PR has two features in it and should be merged as two separate commits, either ask the contributor to break it up into two, or follow the [manual steps](#landing-a-pr-manually).
+
+The commit message should follow our [conventional changelog conventions][conventions]. They are based on the angularjs changelog conventions. The changelog is then generated from these commit messages on release.
+
+The first line of the commit message -- the header, which is the first text box on GitHub -- should be prefixed with a type and optional scope followed by a short description of the commit.
+The type is required. Two common ones are `fix` and `feat` for bug fixes and new features. Scope is optional and can be anything.
+
+The body should contain extra information, potentially copied from the original comment of the PR.
+
+The footer should contain things like whether this is a breaking change or what issues were fixed by this PR.
+
+Here's an example:
+
+```commit
+fix(html5): a regression with html5 tech
+
+This is where you'd explain what the regression is.
+
+Fixes #123
+```
+
+### Landing a PR manually
+
+_Optional:_ ensure you're not in a weird rebase or merge state:
+
+```sh
+git am --abort
+git rebase --abort
+```
+
+Checkout and update the main branch:
+
+```sh
+git checkout main
+git remote update
+git rebase upstream/main
+```
+
+Check out the PR:
+
+```sh
+git fetch upstream pull/{{PR Number}}/head:{{name of branch}}
+git checkout -t {{name of branch}}
+```
+
+> For example:
+>
+> ```sh
+> git fetch upstream pull/123/head:gkatsev-html5-fix
+> git checkout -t gkatsev-html5-fix
+> ```
+
+_Optional:_ If necessary, rebase against main. If you have multiple features in the PR, [landing a PR manually with several changes](#landing-a-pr-manually-with-several-changes)
+
+```sh
+git rebase main
+```
+
+Fix up any issues that arise from the rebase, change back to the main branch and squash merge:
+
+```sh
+git checkout main
+git merge --squash --no-commit gkatsev-html5-fix
+```
+
+The `--no-commit` tells git not to make a commit on your behalf. It does stage everything for you, so, you can instead it:
+
+```sh
+git diff --cached
+```
+
+Now get the author from the original commit:
+
+```sh
+git log -n 1 --pretty=short gkatsev-html5-fix
+```
+
+Which shows:
+
+```txt
+  commit 433c58224f5be34480c8e067ca6c5406ba1c1e9c
+  Author: Gary Katsevman <git@gkatsev.com>
+
+      Update TOC
+```
+
+Now you can commit the change the change with the author, following our commit guidelines
+
+```sh
+git commit --author "Gary Katsevman <git@gkatsev.com>"
+```
+
+Now that it's committed, push to main
+
+```sh
+git push upstream main
+```
+
+Congratulate yourself for a job well done and the contributor for having his change landed in main.
+
+#### Landing a PR manually with several changes
+
+Follow the same steps as before but when you rebase against main, you want to do an interactive rebase and then squash the changes into just a few commits.
+
+```sh
+git rebase -i main
+```
+
+This will give you an output like the following:
+
+```txt
+pick b4dc15d Update CONTRIBUTING.md with latest info
+pick 8592149 Add Dev certificate of origin
+pick 259dee6 Add grunt and doctoc npm scripts
+pick f12af12 Add conventional-changelog-videojs link
+pick ae4613a Update node's CONTRIBUTING.md url
+pick 433c582 Update TOC
+
+# Rebase f599ef4..433c582 onto f599ef4 (6 command(s))
+#
+# Commands:
+# p, pick = use commit
+# r, reword = use commit, but edit the commit message
+# e, edit = use commit, but stop for amending
+# s, squash = use commit, but meld into previous commit
+# f, fixup = like "squash", but discard this commit's log message
+# x, exec = run command (the rest of the line) using shell
+# d, drop = remove commit
+#
+# These lines can be re-ordered; they are executed from top to bottom.
+#
+# If you remove a line here THAT COMMIT WILL BE LOST.
+#
+# However, if you remove everything, the rebase will be aborted.
+#
+# Note that empty commits are commented out
+```
+
+Replace `pick` to `fixup` or `edit` depending on how you want the output to look. You can also re-order the commits, if necessary.
+
+> `fixup` will squash the commit it's infront of up into the commit above it
+>
+> `edit` will allow you to edit the commit message before continuing
+
+```txt
+edit b4dc15d Update CONTRIBUTING.md with latest info
+fixup 8592149 Add Dev certificate of origin
+fixup f12af12 Add conventional-changelog-videojs link
+fixup ae4613a Update node's CONTRIBUTING.md url
+fixup 433c582 Update TOC
+edit 259dee6 Add grunt and doctoc npm scripts
+```
+
+When you get to the edit commits, git will give more information, but you'd want to run ammend the current commit while following our commit guidelines
+
+```sh
+git commit --amend
+```
+
+After going through and making the commits you want, you want to change back to main and then rebase the branch onto main so we get a clean history
+
+```sh
+git rebase gkatsev-html5-fix
+```
+
+This will put our two commits into main:
+
+```txt
+b4dc15d chore(contributing.md): Update CONTRIBUTING.md with latest info <Gary Katsevman>
+259dee6 chore(package.json): Add grunt and doctoc npm scripts <Gary Katsevman>
+9e20386 v5.12.6 <Gary Katsevman>
+```
+
+Now you're ready to push to main as in the normal instructions.
+
+#### I just made a mistake
+
+While `git` allows you to update the remote branch with a force push (`git push -f`). This is generally frowned upon since you're rewriting public history. However, if you just pushed the change and it's been less than 10 minutes since you've done with, you may force push to update the commit, assuming no one else has already pushed after you.
+
+##### I accidentally pushed a broken commit or incorrect commit to main
+
+Assuming no more than 10 minutes have passed, you may force-push to update or remove the commit. If someone else has already pushed to main or 10 minutes have passed, you should instead use the revert command (`git revert`) to revert the commit and then commit the proper change, or just fix it forward with a followup commit that fixes things.
+
+##### I lost changes
+
+Assuming that the changes were committed, even if you lost the commit in your current history does not mean that it is lost. In a lot of cases you can still recover it from the PR branch or if all else fails look at [git's reflog](https://git-scm.com/docs/git-reflog).
+
+##### I accidentally committed a broken change to main
+
+This is a great time to discover that something is broken. Because it hasn't been pushed to GitHub yet, it's very easy to reset the change as if nothing has happened and try again.
+
+To do so, just reset the branch against main.
+
+```sh
+git reset --hard upstream/main
+```
+
+## Video.js releases
+
+Releasing Video.js is partially automated through various scripts.
+To do a release, all you need is just write access to the repo!
+
+Releases in Video.js are done on npm and GitHub and eventually posted on the CDN.
+These are the instructions for the npm/GitHub releases.
+
+When we do a release, we release it as a `next` tag on npm first and then at least a week later, we promote this release to `latest` on npm.
+
+You can promote it using `npm dist-tag add video.js@<version> <tag>`.
+
+### Getting dependencies
+
+#### npm access
+
+To see who currently has access run this:
+
+```sh
+npm owner ls video.js
+```
+
+If you are a core committer, you can request access to npm from one of the current owners.
+Access is managed via an [npm organization][npm org] for [Video.js][vjs npm].
+
+### Deciding what type of version release
+
+Since we follow the [conventional changelog conventions][conventions],
+all commits are prepended with a type, most commonly `feat` and `fix`.
+If all the commits are fix or other types such as `test` or `chore`, then the release will be a `patch` release.
+If there's even one `feat`, the release will be a `minor` release.
+If any commit has a `BREAKING CHANGE` footer, then the release will be a `major` release.
+Most common releases will be either `patch` or `minor`.
+
+### Doing a release
+
+It is also recommended you have a clean clone of Video.js for each release line you want to release.
+This is because different versions have different expectations for release process and have different dependencies.
+Plus, during development you could end up with a dirty repo, so, it just usually easier if you have a clean release repo.
+
+```sh
+# for v8
+git clone git@github.com:videojs/video.js.git videojs-8-release
+# for v7
+git clone git@github.com:videojs/video.js.git videojs-7-release
+```
+
+#### Current Video.js
+
+Make sure go to the main branch and grab the latest updates.
+
+```sh
+git checkout main
+git pull origin main
+```
+
+At this point, you should run `npm install` because dependencies may have changed.
+
+Then, it's mostly a standard npm package release process with running `npm version`, followed by an `npm publish`.
+
+```sh
+npm version {major|minor|patch}
+```
+
+Depending on the commits that have been merged, you can choose from `major`, `minor`, or `patch` as the versioning values.
+See [deciding what type of version release section](#deciding-what-type-of-version-release).
+
+Optionally, you can run `git show` now to verify that the version update and CHANGELOG automation worked as expected.
+
+Afterwards, you want to push the commit and the tag to the repo.
+It's necessary to do this before running `npm publish` because our GitHub release automation
+relies on the commit being available on GitHub.
+
+```sh
+git push --tags origin main
+```
+
+After the tag was pushed, GitHub actions will trigger the `release` workflow, which will do the following:
+
+* Publish to npm with `next` or `next-{n}` depending on your current major version.
+* Create GitHub pre-release with changelog and Netlify preview.
+* Create a GitHub `releases` discussion linked to the GitHub release.
+* Copy files to the CDN with the AWS CLI (this step requires approval, make sure to ping collaborators chat!)
+
+And that's it. Congratulations - you've just released a new version of Video.js.
+
+#### Legacy Video.js (5)
+
+Make sure to go to the 5.x branch and grab the latest updates.
+
+```sh
+git checkout 5.x
+git pull origin 5.x
+```
+
+> _Note:_ you probably need to delete v6 tags due to the way that the our CHANGELOG lib works.
+>
+> You can run this to delete them:
+>
+> ```sh
+> git tag | grep '^v6' | xargs git tag -d
+> ```
+>
+> This will find all tags that start with `^v6` and delete them.
+
+At this point, you should run `npm install` because dependencies may have changed.
+
+Then, we have a script that automates most of the steps for publishing. It's a little trickier than publishing v6.
+
+##### Edit git-semver-tags
+
+You'll need to edit `git-semver-tags` to support our usage of tags that are not part of the branch.
+In the file `node_modules/conventional-changelog-cli/node_modules/conventional-changelog/node_modules/conventional-changelog-core/node_modules/git-semver-tags/index.js`, edit the line that says sets the `cmd` to be:
+
+```js
+var cmd = 'git log --all --date-order --decorate --no-color';
+```
+
+#### And now for the release
+
+After getting rid of the tags and getting the latest updates, you can just run the release script:
+
+```sh
+VJS_GITHUB_USER=gkatsev VJS_GITHUB_TOKEN=123 ./build/bin/release-next.sh
+```
+
+It will prompt you for a version change type, so, input `patch` or `minor` or `major`.
+See [deciding what type of version release section](#deciding-what-type-of-version-release).
+
+When it's done building everything, it'll show you the commit that's made via the default pager (i.e., less).
+At this point you can verify that things look normal rather than, for example, missing all the CSS.
+
+After exiting the pager, it'll make sure you want to continue with publishing.
+
+It will automatically release it as a `next-5` tag on npm.
+
+Then push the local changes up:
+
+```sh
+git push --tags origin 5.x
+```
+
+Also, you'll need to copy the CHANGELOG for this version and manually edit the GitHub release to include it.
+The current release's CHANGELOG could be copied from the [raw CHANGELOG.md file][raw chg] (or locally from the markdown file)
+and then pasted into the correct [GitHub release](https://github.com/videojs/video.js/releases).
+
+### Deploy as a patch to the CDN
+
+Follow the steps on the [CDN repo][cdn repo] for the CDN release process.
+If it's a `next` or `next-5` release, only publish the patch version to the CDN.
+
+When the version gets promoted to `latest` or `latest-5`, the corresponding `minor` or `latest` version should be published to the CDN.
+
+### Announcement
+
+An announcement should automatically make it's way to #announcements channel on [slack][], it uses IFTTT and might take a while.
+
+You can also post it to twitter or ask someone (like @gkatsev) to post on your behalf.
+
+If it's a large enough release, consider writing a blog post as well.
+
+## Doc credit
+
+This collaborator guide was heavily inspired by [node.js's guide](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md)
+
+[issue template]: /.github/ISSUE_TEMPLATE.md
+
+[pr template]: /.github/PULL_REQUEST_TEMPLATE.md
+
+[conventions]: https://github.com/videojs/conventional-changelog-videojs/blob/main/convention.md
+
+[vjs npm]: https://www.npmjs.com/org/videojs
+
+[npm org]: https://docs.npmjs.com/misc/orgs
+
+[slack]: http://slack.videojs.com
+
+[cdn repo]: https://github.com/videojs/cdn
+
+[raw chg]: https://raw.githubusercontent.com/videojs/video.js/5.x/CHANGELOG.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,332 @@
+# Video.js® Contributor Guide
+
+So you want to help out? Great! There's a number of ways you can get involved.
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Other repositories where issues could be filed](#other-repositories-where-issues-could-be-filed)
+- [Filing issues](#filing-issues)
+  - [Reporting a Bug](#reporting-a-bug)
+  - [Requesting a Feature](#requesting-a-feature)
+  - [Labels](#labels)
+- [Contributing code](#contributing-code)
+  - [Building video.js locally](#building-videojs-locally)
+    - [Forking and cloning the repository](#forking-and-cloning-the-repository)
+    - [Installing local dependencies](#installing-local-dependencies)
+    - [Running tests](#running-tests)
+    - [Building videojs](#building-videojs)
+    - [Testing Locally](#testing-locally)
+    - [Sandbox test directory](#sandbox-test-directory)
+    - [Running a local web server](#running-a-local-web-server)
+    - [Watching source and test changes](#watching-source-and-test-changes)
+  - [Making Changes](#making-changes)
+    - [Step 1: Verify](#step-1-verify)
+    - [Step 2: Update remote](#step-2-update-remote)
+    - [Step 3: Branch](#step-3-branch)
+    - [Step 4: Commit](#step-4-commit)
+    - [Step 5: Test](#step-5-test)
+    - [Step 6: Push](#step-6-push)
+  - [Code Style Guide](#code-style-guide)
+- [Developer's Certificate of Origin 1.1](#developers-certificate-of-origin-11)
+- [Doc Credit](#doc-credit)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Other repositories where issues could be filed
+
+There's also other Video.js projects where you can help. (check the [video.js org](https://github.com/videojs) for an up-to-date list of projects)
+
+* [Videojs.com](https://github.com/videojs/videojs.com)
+* [HLS](https://github.com/videojs/videojs-contrib-hls)
+* [DASH](https://github.com/videojs/videojs-contrib-dash)
+* [Youtube Tech](https://github.com/videojs/videojs-youtube)
+* [Vimeo Tech](https://github.com/videojs/videojs-vimeo)
+* [Ads](https://github.com/videojs/videojs-contrib-ads)
+* [Plugin generator](https://github.com/videojs/generator-videojs-plugin)
+* [Linter][linter]
+
+## Filing issues
+
+[GitHub Issues](https://github.com/videojs/video.js/issues) are used for all discussions around the codebase, including **bugs**, **features**, and other **enhancements**.
+
+When filling out an issue, make sure to fill out the questions in the
+
+### Reporting a Bug
+
+**A bug is a demonstrable problem** that is caused by the code in the repository. Good bug reports are extremely helpful. Thank You!
+
+Guidelines for bug reports:
+
+1. If your issue is with a particular video.js plugin or subproject, please open an issue against that project. See [list of some potential other projects above](#other-repositories-where-issues-could-be-filed)
+1. Use the [GitHub issue search](https://github.com/videojs/video.js/issues) — check if the issue has already been reported.
+1. Check if the issue has already been fixed — try to reproduce it using the latest `main` branch in the repository.
+1. Isolate the problem — **create a [reduced test case](https://css-tricks.com/reduced-test-cases/)** with a live example. You can possibly use [this codepen template](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0) as a starting point -- don't forget to update it to the videojs version you use.
+1. Answer all questions in the [issue template][]. The questions in the issue template are designed to try and provide the maintainers with as much information possible to minimize back-and-forth to get the issue resolved.
+
+A good bug report should be as detailed as possible, so that others won't have to follow up for the essential details.
+
+**[File a bug report](https://github.com/videojs/video.js/issues/new)**
+
+### Requesting a Feature
+
+1. [Check the plugin list](https://videojs.com/plugins/) for any plugins that may already support the feature.
+1. [Search the issues](https://github.com/videojs/video.js/issues) for any previous requests for the same feature, and give a thumbs up or +1 on existing requests.
+1. If no previous requests exist, create a new issue. Please be as clear as possible about why the feautre is needed and the intended use case.
+1. Once again, be as details as possible and follow the [issue template][]
+
+**[Request a feature](https://github.com/videojs/video.js/issues/new)**
+
+### Labels
+
+There are a few labels that might be added to your issue or PR by a maintainer. Here's a quick rundown of what they mean:
+
+| Label                    | Issue or PR  | Description                                                                                                                                              |
+| ------------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| confirmed                | Issue and PR | Issue: marks as reproducible by a maintainer. PR: marked by a maintainer as ready to be merged                                                           |
+| 5.x                      | PR           | Marks as a change to the 5.x branch only                                                                                                                 |
+| bug                      | Issue        | Marks as a confirmed bug by a maintainer                                                                                                                 |
+| good first issue         | Issue        | Marked as a good bug or enhancement for first time contributors to Video.js                                                                              |
+| first-timers-only        | Issue        | Marked as a good bug or enhancement to be done by a newcomer to open source                                                                              |
+| minor, patch, major      | PR           | Marks PR with the expected [semver](https://semver.org/) classification of the change                                                                    |
+| needs: more info         | Issue        | Marked by a maintainer as needing more information from the issue reporter. Please update your issue with more information to help us reproduce the bug. |
+| needs: reduced test case | Issue        | Marked by a maintainer as needing a reduced test case from the issue reporter. Please create a test page that we can inspect to help us indentify a bug. |
+
+## Contributing code
+
+To contibute code you'll need to be able to build a copy of Video.js and run tests locally. There are a few requirements before getting started.
+
+* Node.js
+  Video.js uses Node for build and test automation. Node is available for Windows, Mac OS X, Linux, and SunOS, as well as source code if that doesn't scare you. [Download and install Node.js](http://nodejs.org/download/)
+
+### Building video.js locally
+
+#### Forking and cloning the repository
+
+First, [fork](http://help.github.com/fork-a-repo/) the video.js git repository. At the top of every GitHub page, there is a Fork button. Click it, and the forking process will copy Video.js into your own GitHub account.
+
+Clone your fork of the repo into your code directory
+
+```sh
+git clone https://github.com/<your-username>/video.js.git
+```
+
+Navigate to the newly cloned directory
+
+```sh
+cd video.js
+```
+
+Assign the original repo to a remote called "upstream"
+
+```sh
+git remote add upstream https://github.com/videojs/video.js.git
+```
+
+> In the future, if you want to pull in updates to video.js that happened after you cloned the main repo, you can run:
+>
+> ```sh
+> git remote update
+> git checkout main
+> git pull upstream main
+> ```
+
+#### Installing local dependencies
+
+Install the required node.js modules using node package manager
+
+```sh
+npm install
+```
+
+> A note to Windows developers: If you run npm commands, and you find that your command prompt colors have suddenly reversed, you can configure npm to set color to false to prevent this from happening.
+> `npm config set color false`
+> Note that this change takes effect when a new command prompt window is opened; the current window will not be affected.
+
+#### Running tests
+
+Tests can be run either from the shell or from the browser.
+
+To run the tests from the shell, just run
+
+```sh
+npm test
+```
+
+This will build video.js locally and run the test suite using [Karma](https://karma-runner.github.io/1.0/index.html), which runs our tests in actual browsers.
+
+To run tests from the browser, first start a local server with `npm start` (this also watches for changes and rebuilds video.js and the test files as necessary). Then navigate to `http://localhost:9999/test`, and you'll see a page that displays the results of all the tests. To rerun the tests after making changes, just refresh the page. To run an individual test, click the "Rerun" link next to the test's title.
+
+#### Building videojs
+
+To build video.js, simply run
+
+```sh
+npm run build
+```
+
+This outputs an `es5/` and `dist/` folder. The `es5/` folder is used by bundling tools like browserify and webpack to package video.js into projects. The `dist/` folder has pre-compiled versions of video.js, including a minified version and the CSS file. This file can be included in page via a `<script></script>` tag.
+
+#### Testing Locally
+
+Besides running automated tests, you often want to run video.js manually and play around with things as you're developing. A few things are provided to make it easier.
+
+#### Sandbox test directory
+
+There's a sandbox directory where you can add any file and it won't get tracked in git. To start you can copy the example index file.
+
+```sh
+cp sandbox/index.html.example sandbox/index.html
+```
+
+See [the following section](#running-a-local-web-server) for how to open the page in a browser.
+
+#### Running a local web server
+
+This ties in nicely with the sandbox directory. You can always open the `sandbox/index.html` file directly but in some cases it may not work properly.
+
+> To get around this you must use a local web server.
+
+To run the local webserver:
+
+```sh
+npm start
+open http://localhost:9999/sandbox/index.html
+```
+
+The latter does some extra work which will be described in the next section.
+
+#### Watching source and test changes
+
+As you're developing, you want the build to re-run and update itself, and potentially re-run the tests. In addition, you want to launch a local web-server that you can open the `sandbox` directory in.
+To do so, you just need to run
+
+```sh
+npm start
+```
+
+This sets up the local webserver using connect and then watches source files, test files, and CSS files for you and rebuilds things as they happen.
+
+### Making Changes
+
+#### Step 1: Verify
+
+Whether you're adding something new, making something better, or fixing a bug, you'll first want to search the [GitHub issues](https://github.com/videojs/video.js/issues) and [plugins list](https://github.com/videojs/video.js/wiki/Plugins) to make sure you're aware of any previous discussion or work. If an unclaimed issue exists, claim it via a comment. If no issue exists for your change, submit one, following the [issue filing guidelines](#filing-issues).
+
+#### Step 2: Update remote
+
+Before starting work, you want to update your local repository to have all the latest changes.
+
+```sh
+git remote update
+git checkout main
+git rebase upstream/main
+```
+
+#### Step 3: Branch
+
+You want to do your work in a separate branch.
+
+```sh
+git checkout -b my-branch
+```
+
+#### Step 4: Commit
+
+Commit changes as you go. Write thorough descriptions of your changes in your commit messages.
+For more information see our [conventional changelog guidelines for video.js](https://github.com/videojs/conventional-changelog-videojs/blob/main/convention.md)
+Follow these guidelines:
+
+1. The first line should be less than 50 characters and contain a short description of the commit.
+1. The body should contain a more detailed description. It can contain things like reasoning for the change and specifics of what changed.
+1. A footer can be added if this fixes a particular issue on GitHub.
+
+```sh
+git add src/js/player.js
+git commit
+```
+
+An example of the first line of a commit message: `fix: changed the footer to correctly display foo`
+
+In the body of the commit message, we can talk about why we made the change. What the change entails.
+Any testing considerations or things to think about when looking at the commit. For Example:
+
+```txt
+fix: one line commit explanation
+
+In the body of the commit message, we can talk about why we made the change. What the change entails.
+
+Any testing considerations or things to think about when looking at the commit.
+
+Fixes #123. The footer can contain Fixes messages.
+```
+
+> Make sure that git knows your name and email:
+>
+> ```sh
+> git config --global user.name "Random User"
+> git config --global user.email "random.user@example.com"
+> ```
+
+#### Step 5: Test
+
+Any code change should come with corresponding test changes. Especially bug fixes.
+Tests attached to bug fixes should fail before the change and succeed with it.
+
+```sh
+npm test
+```
+
+See [Running tests](#running-tests) for more information.
+
+#### Step 6: Push
+
+```sh
+git push origin my-branch
+```
+
+Then go to the [repo page](https://github.com/videojs/video.js) and click the "Pull Request" button and fill out the [pull request template](/.github/PULL_REQUEST_TEMPLATE.md)
+
+### Code Style Guide
+
+Our javascript is linted using [videojs-standard][linter].
+
+## [Developer's Certificate of Origin 1.1](https://github.com/nodejs/node/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license
+  indicated in the file; or
+
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
+
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified
+  it.
+
+* (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.
+
+## Doc Credit
+
+This doc was inspired by some great contribution guide examples including [contribute.md template](https://github.com/contribute-md/contribute-md-template),
+[grunt](https://github.com/gruntjs/grunt/wiki/Contributing),
+[html5 boilerplate](https://github.com/h5bp/html5-boilerplate/blob/master/CONTRIBUTING.md),
+[jquery](https://github.com/jquery/jquery/blob/master/CONTRIBUTING.md),
+and [node.js](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md).
+
+[issue template]: /.github/ISSUE_TEMPLATE.md
+
+[linter]: https://github.com/videojs/standard

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,153 @@
+# Video.js® Community Governance
+
+This document sets up the guidelines for ongoing governance and maintenance of Video.js.
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Brightcove’s Position](#brightcoves-position)
+- [Shared Responsibility and the Technical Steering Committee](#shared-responsibility-and-the-technical-steering-committee)
+  - [Current TSC Members](#current-tsc-members)
+  - [Corporate Shepherd of the TSC](#corporate-shepherd-of-the-tsc)
+- [Collaborators](#collaborators)
+  - [Types of Collaborator](#types-of-collaborator)
+    - [Community Collaborators](#community-collaborators)
+    - [Core Collaborators](#core-collaborators)
+  - [Current Collaborators](#current-collaborators)
+- [Contributors](#contributors)
+- [TSC Membership](#tsc-membership)
+- [TSC Meetings](#tsc-meetings)
+- [Consensus Seeking Process](#consensus-seeking-process)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Brightcove’s Position
+
+Brightcove holds the Video.js trademark and has been the maintainer and corporate steward of the project for over a decade. Video.js is the core of the Brightcove Player and, as such, its maintenance is commercially critical to the company.
+
+However, Brightcove acknowledges that the scope of Video.js is broader than its commercial interests. Many companies and developers around the globe use Video.js, so the company recognizes the value of a governance model that embraces collaboration with the wider community.
+
+Brightcove welcomes the expertise and passion of individuals from outside the company who donate their time to help make Video.js the best open source web media player available.
+
+## Shared Responsibility and the Technical Steering Committee
+
+The Video.js project is jointly governed by Brightcove and a Technical Steering Committee (TSC). Responsibilities are divided in the following way:
+
+* Brightcove’s responsibility is to provide logistical and administrative control of the project as well as staffing the day-to-day maintenance of Video.js. Brightcove collaborates with the TSC as a member in the Corporate Shepherd role.
+* The TSC’s responsibility is to discuss, debate, and define the overall technical direction of the project by consensus. In large part, this means representing the perspective of users who are external to Brightcove.
+
+Initial membership invitations to the TSC were given to founders of the project and individuals who had been long-term active contributors to Video.js and who had significant experience with the management of the project.
+
+Membership is expected to evolve over time according to the needs of the project and the contributions of individuals.
+
+### Current TSC Members
+
+* [Ben Clifford](https://github.com/mister-ben) (Brightcove)
+* [Pat O’Neill](https://github.com/misteroneill) (Brightcove, poneill@brightcove.com)
+* [Garrett Singer](https://github.com/gesinger) (LinkedIn)
+* [Steve Heffernan](https://github.com/heff) (Mux)
+* [Matthew McClure](https://github.com/mmcc) (Mux)
+* [Gary Katsevman](https://github.com/gkatsev) (Mux)
+
+### Corporate Shepherd of the TSC
+
+In recognition of its long-term commitment to Video.js, Brightcove holds the special distinction of Corporate Shepherd for Video.js, which involves:
+
+* Brightcove occupies a minimum of one permanent seat on the TSC, reserved for an employee who actively contributes to the project.
+* Brightcove is prominently acknowledged as Corporate Shepherd on the Video.js website.
+* Should the TSC be unable to reach consensus on a topic, Brightcove will settle the question at hand.
+
+## Collaborators
+
+The GitHub repositories in the Video.js organization are maintained by Brightcove and the TSC. Additional Collaborators are added and removed by Brightcove and the TSC on an ongoing basis. All TSC members are considered Collaborators implicitly.
+
+All Collaborators have the following permissions:
+
+* Approve pull requests
+* Merge pull requests
+* Push new tags/releases
+
+Collaborators meet monthly on an optional video call.
+
+### Types of Collaborator
+
+There are two types of Collaborator. A guide for Collaborators of both types is maintained in the Video.js [COLLABORATOR_GUIDE.md](./COLLABORATOR_GUIDE.md). They are distinguished as follows:
+
+#### Community Collaborators
+
+Community Collaborators are individuals from the community who make multiple significant and valuable contributions to Video.js.
+
+These are nominated by existing Collaborators and their nominations are discussed during the monthly TSC meeting.
+
+Community Collaborators who are inactive in the project for a period of 6 months or more are considered to have resigned their status and their access will be revoked.
+
+#### Core Collaborators
+
+Core Collaborators are employees of Brightcove.
+
+Because these individuals’ employment involves Video.js contribution, this status is automatic and persists throughout the duration of their employment.
+
+Core Collaborators who leave Brightcove become Community Collaborators.
+
+### Current Collaborators
+
+* Sindhu Barathan (Core)
+* Alex Barstow (Core)
+* Brandon Casey
+* Dzianis Dashkevich (Core)
+* Lahiru Dayananda
+* Owen Edwards
+* Phil Hale (Core)
+* Carey Hinoki
+* David LaPalomento
+* Usman Omar (Core)
+* Roman Pougatchev (Core)
+* Sarah Rimron-Soutter (Core)
+* Jon-Carlos Rivera
+* Walter Seymour (Core)
+* Harisha Swaminathan (Core)
+* Adam Waldron (Core)
+
+## Contributors
+
+Anyone who makes (or wishes to make) a contribution of any significance through a code patch is considered a Contributor.
+
+The full list of Contributors is provided by GitHub in each repository.
+
+A guide for Contributors is maintained in the Video.js [CONTRIBUTING.md](https://github.com/videojs/video.js/blob/main/CONTRIBUTING.md).
+
+## TSC Membership
+
+Collaborators who, over multiple years, show a long-term dedication to maintaining and improving Video.js may be considered for TSC membership should the TSC see a need for their expertise or for balance in its membership.
+
+The TSC may add members by a standard TSC motion. A TSC member may be removed from the TSC by voluntary resignation or by a standard TSC motion. A TSC member who does not participate in TSC proceedings (without due cause) for a period of one year will be considered to have resigned.
+
+Changes to TSC membership should be posted in the agenda, and may be suggested as any other agenda item (see "TSC Meetings" below).
+
+No more than half of the TSC members may be employed by the same company - including Brightcove. If a situation arises where more than half of the TSC membership shares an employer, then the situation must be remedied by the resignation or removal of one or more TSC members affiliated with the over-represented employer - or the addition of new TSC members from other employers.
+
+## TSC Meetings
+
+The TSC meets monthly on a video call.
+
+Items are added to the TSC agenda which are considered contentious or are modifications of governance, contribution policy, TSC membership, or release process.
+
+The intention of the agenda is not to approve or review pull requests. That should happen continuously on GitHub and be handled by the larger group of Collaborators.
+
+Any community member or contributor can ask that something be added to the next meeting's agenda by logging a GitHub Issue. Any Collaborator or TSC member can add the item to the agenda by adding the _tsc-agenda_ tag to the issue.
+
+TSC members can add any items they like to the agenda at the beginning of each meeting. The TSC cannot veto or remove items from the agenda before time is granted for discussion.
+
+The TSC may invite representatives from outside the project to participate in a non-voting capacity.
+
+## Consensus Seeking Process
+
+The TSC follows a Consensus Seeking decision making model.
+
+When an agenda item has appeared to reach a consensus, a TSC member can call for a final vote.
+
+If an agenda item cannot reach a consensus, a TSC member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be approved by a majority of the TSC or else the discussion will continue.
+
+In all voting processes, a simple majority (half plus one) wins.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Video.js® Administration
+
+This repository contains documentation pertaining to the overall Video.js organization and _all_ projects contained within.
+
+The documents contained in this repository are:
+
+* [Contributor Code of Conduct](./CODE_OF_CONDUCT.md) for all Video.js projects
+* [Collaborators Guide](./COLLABORATOR_GUIDE.md) for contributors who earn write access to Video.js repositories
+* [Contributor Guide](./CONTRIBUTING.md) for general community contributors
+* [Community Governance](./GOVERNANCE.md) structure for Video.js organization
+
+## License
+
+Video.js projects are licensed under the Apache License, Version 2.0.
+
+Video.js is a registered trademark of [Brightcove, Inc][bc].
+
+<!-- START doctoc -->
+<!-- END doctoc -->
+
+[bc]: https://www.brightcove.com/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,911 @@
+{
+  "name": "@videojs/admin",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@videojs/admin",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "doctoc": "^2.2.1",
+        "husky": "^8.0.3"
+      }
+    },
+    "node_modules/@textlint/ast-node-types": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
+      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
+      "dev": true
+    },
+    "node_modules/@textlint/markdown-to-ast": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-12.6.1.tgz",
+      "integrity": "sha512-T0HO+VrU9VbLRiEx/kH4+gwGMHNMIGkp0Pok+p0I33saOOLyhfGvwOKQgvt2qkxzQEV2L5MtGB8EnW4r5d3CqQ==",
+      "dev": true,
+      "dependencies": {
+        "@textlint/ast-node-types": "^12.6.1",
+        "debug": "^4.3.4",
+        "mdast-util-gfm-autolink-literal": "^0.1.3",
+        "remark-footnotes": "^3.0.0",
+        "remark-frontmatter": "^3.0.0",
+        "remark-gfm": "^1.0.0",
+        "remark-parse": "^9.0.0",
+        "traverse": "^0.6.7",
+        "unified": "^9.2.2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
+      "integrity": "sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "node_modules/anchor-markdown-header": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.6.0.tgz",
+      "integrity": "sha512-v7HJMtE1X7wTpNFseRhxsY/pivP4uAJbidVhPT+yhz4i/vV1+qx371IXuV9V7bN6KjFtheLJxqaSm0Y/8neJTA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "~10.1.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
+      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/doctoc": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/doctoc/-/doctoc-2.2.1.tgz",
+      "integrity": "sha512-qNJ1gsuo7hH40vlXTVVrADm6pdg30bns/Mo7Nv1SxuXSM1bwF9b4xQ40a6EFT/L1cI+Yylbyi8MPI4G4y7XJzQ==",
+      "dev": true,
+      "dependencies": {
+        "@textlint/markdown-to-ast": "^12.1.1",
+        "anchor-markdown-header": "^0.6.0",
+        "htmlparser2": "^7.2.0",
+        "minimist": "^1.2.6",
+        "underscore": "^1.13.2",
+        "update-section": "^0.3.3"
+      },
+      "bin": {
+        "doctoc": "doctoc.js"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
+      "dev": true
+    },
+    "node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "dev": true,
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "dev": true,
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dev": true,
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
+      "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-footnote": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/mdast-util-footnote/-/mdast-util-footnote-0.1.7.tgz",
+      "integrity": "sha512-QxNdO8qSxqbO2e3m09KwDKfWiLgqyCurdWTQ198NpbZ2hxntdc+VKS4fDJCmNWbAroUdYnSthu+XbZ8ovh8C3w==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-to-markdown": "^0.6.0",
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-0.2.0.tgz",
+      "integrity": "sha512-FHKL4w4S5fdt1KjJCwB0178WJ0evnyyQr5kXTM3wrOVpytD0hrkvd+AOOjU9Td8onOejCkmZ+HQRT3CZ3coHHQ==",
+      "dev": true,
+      "dependencies": {
+        "micromark-extension-frontmatter": "^0.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
+      "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-gfm-autolink-literal": "^0.1.0",
+        "mdast-util-gfm-strikethrough": "^0.2.0",
+        "mdast-util-gfm-table": "^0.1.0",
+        "mdast-util-gfm-task-list-item": "^0.1.0",
+        "mdast-util-to-markdown": "^0.6.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
+      "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
+      "dev": true,
+      "dependencies": {
+        "ccount": "^1.0.0",
+        "mdast-util-find-and-replace": "^1.1.0",
+        "micromark": "^2.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
+      "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-to-markdown": "^0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+      "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+      "dev": true,
+      "dependencies": {
+        "markdown-table": "^2.0.0",
+        "mdast-util-to-markdown": "~0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+      "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-to-markdown": "~0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.0.0",
+        "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.0.0",
+        "parse-entities": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-footnote": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-footnote/-/micromark-extension-footnote-0.3.2.tgz",
+      "integrity": "sha512-gr/BeIxbIWQoUm02cIfK7mdMZ/fbroRpLsck4kvFtjbzP4yi+OPVbnukTc/zy0i7spC2xYE/dbX1Sur8BEDJsQ==",
+      "dev": true,
+      "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-0.2.2.tgz",
+      "integrity": "sha512-q6nPLFCMTLtfsctAuS0Xh4vaolxSFUWUWR6PZSrXXiRy+SANGllpcqdXFv2z07l0Xz/6Hl40hK0ffNCJPH2n1A==",
+      "dev": true,
+      "dependencies": {
+        "fault": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
+      "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
+      "dev": true,
+      "dependencies": {
+        "micromark": "~2.11.0",
+        "micromark-extension-gfm-autolink-literal": "~0.5.0",
+        "micromark-extension-gfm-strikethrough": "~0.6.5",
+        "micromark-extension-gfm-table": "~0.4.0",
+        "micromark-extension-gfm-tagfilter": "~0.3.0",
+        "micromark-extension-gfm-task-list-item": "~0.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
+      "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
+      "dev": true,
+      "dependencies": {
+        "micromark": "~2.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
+      "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
+      "dev": true,
+      "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
+      "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
+      "dev": true,
+      "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
+      "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
+      "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
+      "dev": true,
+      "dependencies": {
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "dev": true,
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-footnotes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-3.0.0.tgz",
+      "integrity": "sha512-ZssAvH9FjGYlJ/PBVKdSmfyPc3Cz4rTWgZLI4iE/SX8Nt5l3o3oEjv3wwG5VD7xOjktzdwp5coac+kJV9l4jgg==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-footnote": "^0.1.0",
+        "micromark-extension-footnote": "^0.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-3.0.0.tgz",
+      "integrity": "sha512-mSuDd3svCHs+2PyO29h7iijIZx4plX0fheacJcAoYAASfgzgVIcXGYSq9GFyYocFLftQs8IOmmkgtOovs6d4oA==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-frontmatter": "^0.2.0",
+        "micromark-extension-frontmatter": "^0.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
+      "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-gfm": "^0.1.0",
+        "micromark-extension-gfm": "^0.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-from-markdown": "^0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
+      "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/trough": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "dev": true
+    },
+    "node_modules/unified": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+      "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
+      "dev": true,
+      "dependencies": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/update-section": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/update-section/-/update-section-0.3.3.tgz",
+      "integrity": "sha512-BpRZMZpgXLuTiKeiu7kK0nIPwGdyrqrs6EDSaXtjD/aQ2T+qVo9a5hRC3HN3iJjCMxNT/VxoLGQ7E/OzE5ucnw==",
+      "dev": true
+    },
+    "node_modules/vfile": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@videojs/admin",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Documentation pertaining to the overall Video.js organization and all projects contained within",
+  "main": "index.js",
+  "scripts": {
+    "build": "doctoc --notitle *.md",
+    "test": "exit 0",
+    "prepare": "husky install"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/videojs/admin.git"
+  },
+  "author": "Brightcove, Inc.",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/videojs/admin/issues"
+  },
+  "homepage": "https://github.com/videojs/admin/blob/main/README.md",
+  "devDependencies": {
+    "doctoc": "^2.2.1",
+    "husky": "^8.0.3"
+  }
+}


### PR DESCRIPTION
Updates README.md.

Adds the following documents from the Video.js repo:

- CODE_OF_CONDUCT.md
- COLLABORATOR_GUIDE.md
- CONTRIBUTING.md

Contents are unchanged (except main headings, which now contain `Video.js®` as per Brightcove style guide). Some formatting changes (such as inconsistent use of newlines within paragraphs) were made.

Adds a new community governance document:

- GOVERNANCE.md

Adds doctoc for tables of contents and a husky pre-commit hook to keep them up to date.