### PR TITLE
COC applies to all participants - not just contributors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
-# Video.js® Contributor Code of Conduct
+# Video.js® Code of Conduct
 
-Please note that projects within the Video.js organization are released with a Contributor Code of Conduct. By participating in any of these projects you agree to abide by its terms.
+Please note that projects within the Video.js organization are released with a Code of Conduct. By participating in any of these projects you agree to abide by its terms.
 
 ## Table of Contents
 


### PR DESCRIPTION
The code of conduct applies to _all_ participants (issue creators, commenters, etc) - not just "contributors" which could be interpreted as individuals who commit code.